### PR TITLE
Add localStorage persistence for rides list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 4.10.0
+
+### Minor Changes
+
+- Add persistence for instant load and offline access
+
 ## 4.9.3
 
 ### Patch Changes

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,9 @@
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/outfit": "^5.2.8",
         "@hookform/resolvers": "^5.2.2",
+        "@tanstack/query-sync-storage-persister": "^5.95.2",
         "@tanstack/react-query": "^5.95.2",
+        "@tanstack/react-query-persist-client": "^5.95.2",
         "@tanstack/react-router": "^1.168.3",
         "@tanstack/react-router-devtools": "^1.166.11",
         "@tanstack/react-start": "^1.167.5",
@@ -608,9 +610,15 @@
 
     "@tanstack/query-devtools": ["@tanstack/query-devtools@5.95.2", "", {}, "sha512-QfaoqBn9uAZ+ICkA8brd1EHj+qBF6glCFgt94U8XP5BT6ppSsDBI8IJ00BU+cAGjQzp6wcKJL2EmRYvxy0TWIg=="],
 
+    "@tanstack/query-persist-client-core": ["@tanstack/query-persist-client-core@5.95.2", "", { "dependencies": { "@tanstack/query-core": "5.95.2" } }, "sha512-Opfj34WZ594YXpEcZEs8WBiyPGrjrKlGILfk/Ss283uwWQ36C5nX3tRY/bBiXmM82KWauUuNvahwGwiyco/8cQ=="],
+
+    "@tanstack/query-sync-storage-persister": ["@tanstack/query-sync-storage-persister@5.95.2", "", { "dependencies": { "@tanstack/query-core": "5.95.2", "@tanstack/query-persist-client-core": "5.95.2" } }, "sha512-LLbfRkTF8w9caoOb4Q6TNsh8MFLzrf4FmxSu3D94BcbN6sZf0MhuI+A5thrT6/MAgqQGKShOeRTUu3ziUXOFuw=="],
+
     "@tanstack/react-query": ["@tanstack/react-query@5.95.2", "", { "dependencies": { "@tanstack/query-core": "5.95.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA=="],
 
     "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.95.2", "", { "dependencies": { "@tanstack/query-devtools": "5.95.2" }, "peerDependencies": { "@tanstack/react-query": "^5.95.2", "react": "^18 || ^19" } }, "sha512-AFQFmbznVkbtfpx8VJ2DylW17wWagQel/qLstVLkYmNRo2CmJt3SNej5hvl6EnEeljJIdC3BTB+W7HZtpsH+3g=="],
+
+    "@tanstack/react-query-persist-client": ["@tanstack/react-query-persist-client@5.95.2", "", { "dependencies": { "@tanstack/query-persist-client-core": "5.95.2" }, "peerDependencies": { "@tanstack/react-query": "^5.95.2", "react": "^18 || ^19" } }, "sha512-i3fvzD8gaLgQyFvRc/+iSUr60aL31tMN+5QM11zdPRg0K9CirIQjHD7WgXFBnD29KJDvcjcv7OrIBaPwZ+H9xw=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.168.3", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.2", "@tanstack/router-core": "1.168.3", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-hMWXhckeaSvjepHT5x9tUYJVXMvT/kUjaVHOUDmCfyOBtjxJNYJKbEWClXoopGwWlHjRTAzhsndhnQQRbIiKmA=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,7 +53,7 @@ const eslintConfig = [
   },
   {
     files: ["**/*.ts", "**/*.tsx"],
-    ignores: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+    ignores: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx", "vite.config.ts"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rides",
-  "version": "4.9.3",
+  "version": "4.10.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -21,7 +21,9 @@
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/outfit": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
+    "@tanstack/query-sync-storage-persister": "^5.95.2",
     "@tanstack/react-query": "^5.95.2",
+    "@tanstack/react-query-persist-client": "^5.95.2",
     "@tanstack/react-router": "^1.168.3",
     "@tanstack/react-router-devtools": "^1.166.11",
     "@tanstack/react-start": "^1.167.5",

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,38 +1,60 @@
 import { FilterProvider } from "@/contexts/FilterContext";
 import { Auth0Provider } from "@auth0/auth0-react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
+import { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { useEffect, useState, type ReactNode } from "react";
+
+const RIDES_GC_TIME = 24 * 60 * 60 * 1000; // 24 hours
 
 const AUTH0_DOMAIN = import.meta.env.VITE_AUTH0_DOMAIN!;
 const AUTH0_CLIENT_ID = import.meta.env.VITE_AUTH0_CLIENT_ID!;
 const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE!;
 
 export function Providers({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 2 * 60 * 1000, // 2 minutes - data considered fresh
-            gcTime: 10 * 60 * 1000, // 10 minutes - cache retention
-            refetchOnWindowFocus: false, // Don't refetch when tab regains focus
-          },
-        },
-      }),
+  const [persister] = useState(() =>
+    createSyncStoragePersister({
+      storage: typeof window !== "undefined" ? window.localStorage : null,
+      key: "rides-query-cache",
+    }),
   );
+
+  const [queryClient] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 2 * 60 * 1000, // 2 minutes - data considered fresh
+          gcTime: 10 * 60 * 1000, // 10 minutes - cache retention
+          refetchOnWindowFocus: false, // Don't refetch when tab regains focus
+        },
+      },
+    });
+    // Rides need a longer gcTime so persisted data survives across sessions
+    client.setQueryDefaults(["rides"], { gcTime: RIDES_GC_TIME });
+    return client;
+  });
 
   // Defer Auth0 init to avoid hydration mismatch (window.location not available during SSR)
   const [authReady, setAuthReady] = useState(false);
   useEffect(() => setAuthReady(true), []);
 
   const content = (
-    <QueryClientProvider client={queryClient}>
+    <PersistQueryClientProvider
+      client={queryClient}
+      persistOptions={{
+        persister,
+        maxAge: RIDES_GC_TIME,
+        dehydrateOptions: {
+          shouldDehydrateQuery: (query) => query.queryKey[0] === "rides",
+        },
+      }}
+    >
       <FilterProvider>
         {children}
         <ReactQueryDevtools initialIsOpen={false} />
       </FilterProvider>
-    </QueryClientProvider>
+    </PersistQueryClientProvider>
   );
 
   if (!authReady) return content;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.js",
-    "eslint.config.mjs",
-    "vite.config.ts"
+    "eslint.config.mjs"
   ],
   "compilerOptions": {
     "target": "esnext",
@@ -37,6 +36,7 @@
     "build",
     ".output",
     ".vinxi",
+    "vite.config.ts",
     "**/*.test.ts",
     "**/*.test.tsx"
   ]


### PR DESCRIPTION
Uses @tanstack/react-query-persist-client with createSyncStoragePersister to hydrate the rides cache from localStorage on startup for an instant-on experience. Only rides queries are persisted via shouldDehydrateQuery filter. Rides gcTime extended to 24h to survive across sessions. Guards window access with typeof check for SSR compatibility.

Also excludes vite.config.ts from tsc and ESLint type-aware linting to fix pre-existing excessive stack depth errors.